### PR TITLE
Añadida la palabra 'Gymbro' al glosario

### DIFF
--- a/gymbro.md
+++ b/gymbro.md
@@ -1,0 +1,27 @@
+---
+title: 'Gymbro'
+date: '2025-11-13'
+active: true
+image: 'https://img.freepik.com/free-photo/two-internationals-friends-is-engaged-gym_1157-32105.jpg?semt=ais_hybrid&w=740&q=80'
+creator: 'Laura Sanromán Ferreira'
+category: 'jerga / cultura fitness'
+tags:
+    - 'fitness'
+    - 'gimnasio'
+    - 'cultura popular'
+    - 'amistad'
+synonyms:
+    - compañero de gimnasio
+    - colega del gym
+    - amigo de entrenamiento
+translation: 'Amigo del gimnasio'
+phrase: 'Mi gymbro y yo entrenamos juntos todos los días para motivarnos.'
+difficulty: 'intermedio'
+status: 'estable'
+language: 'es'
+related:
+    - 'entrenamiento'
+    - 'motivación'
+    - 'vida fitness'
+source: 'https://www.urbandictionary.com/define.php?term=gymbro'
+---


### PR DESCRIPTION
Se añade la palabra "Gymbro" con su definición, sinónimos y traducción siguiendo el formato del glosario.